### PR TITLE
Update to 1.12 (Fixes #17)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.sainttx</groupId>
     <artifactId>auctions</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.1-SNAPSHOT</version>
 
     <name>Auctions</name>
     <description>An elegant auctioning solution that allows text tooltips for auctioned items</description>
@@ -18,6 +18,10 @@
             <comments>License on all contributions</comments>
         </license>
     </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <repositories>
         <repository>
@@ -50,13 +54,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.9.2-R0.1-SNAPSHOT</version>
+            <version>1.12-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
             <artifactId>VaultAPI</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/sainttx/auctions/AuctionPlugin.java
+++ b/src/main/java/com/sainttx/auctions/AuctionPlugin.java
@@ -34,7 +34,19 @@ import com.sainttx.auctions.structure.messages.group.GlobalChatGroup;
 import com.sainttx.auctions.structure.messages.group.HerochatGroup;
 import com.sainttx.auctions.structure.messages.handler.ActionBarMessageHandler;
 import com.sainttx.auctions.structure.messages.handler.TextualMessageHandler;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.text.NumberFormat;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+
 import net.milkbowl.vault.economy.Economy;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -43,15 +55,6 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.mcstats.MetricsLite;
-
-import java.io.File;
-import java.io.IOException;
-import java.text.NumberFormat;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.UUID;
-import java.util.logging.Level;
 
 /**
  * The auction plugin class
@@ -172,7 +175,8 @@ public class AuctionPlugin extends JavaPlugin {
     @SuppressWarnings("deprecation")
     private void checkOutdatedConfig() {
         try {
-            Configuration def = YamlConfiguration.loadConfiguration(getResource("config.yml"));
+            InputStreamReader reader = new InputStreamReader(getResource("config.yml"));
+            Configuration def = YamlConfiguration.loadConfiguration(reader);
             int version = def.getInt("general.configurationVersion");
 
             if (getConfig().getInt("general.configurationVersion") < version) {


### PR DESCRIPTION
I replaced .loadConfiguration(InputStream) with .loadConfiguration(Reader). The old method was removed in the new version of Spigot. The reader will automatically closed by the yaml library. So don't have to care about cleaning it up.

I also added a source encoding property to the pom configuration, because Maven otherwise prints a warning and it could make it difficult to write code for international developers.