### PR TITLE
Update to 1.13

### DIFF
--- a/Auctions-API/pom.xml
+++ b/Auctions-API/pom.xml
@@ -12,6 +12,21 @@
 
     <artifactId>auctions-api</artifactId>
 
+    <repositories>
+        <repository>
+            <id>maven.sk89q.com</id>
+            <url>http://maven.sk89q.com/repo/</url>
+        </repository>
+        <repository>
+            <id>NotFab</id>
+            <url>https://maven.notfab.net/SpigotMC</url>
+        </repository>
+        <repository>
+            <id>vault-repo</id>
+            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+        </repository>
+    </repositories>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/Auctions-Herochat/pom.xml
+++ b/Auctions-Herochat/pom.xml
@@ -20,16 +20,16 @@
 
     <repositories>
         <repository>
-            <id>maven.sainttx.com-snapshot</id>
-            <url>http://maven.sainttx.com/artifactory/libs-snapshot-local</url>
+            <id>hero</id>
+            <url>http://maven.elmakers.com/repository/</url>
         </repository>
     </repositories>
 
     <dependencies>
         <dependency>
-            <groupId>com.dthielke</groupId>
-            <artifactId>herochat</artifactId>
-            <version>5.6.7-SNAPSHOT</version>
+            <groupId>com.dthielke.herochat</groupId>
+            <artifactId>HeroChat</artifactId>
+            <version>5.6.5-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/Auctions/pom.xml
+++ b/Auctions/pom.xml
@@ -27,13 +27,21 @@
             <id>maven.sk89q.com</id>
             <url>http://maven.sk89q.com/repo/</url>
         </repository>
+        <repository>
+            <id>NotFab</id>
+            <url>https://maven.notfab.net/SpigotMC</url>
+        </repository>
+        <repository>
+            <id>vault-repo</id>
+            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+        </repository>
     </repositories>
 
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.8-R0.1-SNAPSHOT</version>
+            <version>1.13-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -59,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.mcstats.bukkit</groupId>
-            <artifactId>metrics-lite</artifactId>
+            <artifactId>metrics</artifactId>
             <version>R8-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/Auctions/src/main/java/com/sainttx/auctions/AuctionPluginImpl.java
+++ b/Auctions/src/main/java/com/sainttx/auctions/AuctionPluginImpl.java
@@ -57,10 +57,11 @@ import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.mcstats.MetricsLite;
+import org.mcstats.Metrics;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -150,7 +151,7 @@ public class AuctionPluginImpl extends JavaPlugin implements AuctionPlugin {
 
         // Enable plugin metrics
         try {
-            MetricsLite metrics = new MetricsLite(this);
+            Metrics metrics = new Metrics(this);
             metrics.start();
         } catch (Exception ignored) {
         }
@@ -208,7 +209,7 @@ public class AuctionPluginImpl extends JavaPlugin implements AuctionPlugin {
     @SuppressWarnings("deprecation")
     private void checkOutdatedConfig() {
         try {
-            Configuration def = YamlConfiguration.loadConfiguration(getResource("config.yml"));
+            Configuration def = YamlConfiguration.loadConfiguration(new InputStreamReader(getResource("config.yml")));
             int version = def.getInt("general.configurationVersion");
 
             if (getConfig().getInt("general.configurationVersion") < version) {

--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,12 @@
             <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
         </repository>
         <repository>
-            <id>maven.sainttx.com-snapshot</id>
-            <url>http://maven.sainttx.com/artifactory/libs-snapshot-local</url>
+            <id>NotFab</id>
+            <url>https://maven.notfab.net/SpigotMC</url>
         </repository>
         <repository>
             <id>vault-repo</id>
-            <url>http://nexus.theyeticave.net/content/repositories/pub_releases</url>
+            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
         </repository>
     </repositories>
 
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <version>1.13-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This adds support to 1.13, It still doesn't work because of sk89q's ParametricBuilder classes not being up-to-date, however, even WorldEdit isn't working on 1.13 so might as well merge this if possible and just update that dependency later.

Error for @sk89q depend:
```
java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor()Lcom/google/common/util/concurrent/ListeningExecutorService;
        at com.sk89q.intake.parametric.ParametricBuilder.<init>(ParametricBuilder.java:53) ~[?:?]
        at com.sainttx.auctions.AuctionPluginImpl.onEnable(AuctionPluginImpl.java:163) ~[?:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:264) ~[Spigot.jar:git-Spigot-2440e18-60d7982]
        at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:339) [Spigot.jar:git-Spigot-2440e18-60d7982]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:403) [Spigot.jar:git-Spigot-2440e18-60d7982]
        at org.bukkit.craftbukkit.v1_13_R2.CraftServer.enablePlugin(CraftServer.java:427) [Spigot.jar:git-Spigot-2440e18-60d7982]
        at org.bukkit.craftbukkit.v1_13_R2.CraftServer.enablePlugins(CraftServer.java:341) [Spigot.jar:git-Spigot-2440e18-60d7982]
        at net.minecraft.server.v1_13_R2.MinecraftServer.l(MinecraftServer.java:582) [Spigot.jar:git-Spigot-2440e18-60d7982]
        at net.minecraft.server.v1_13_R2.MinecraftServer.a(MinecraftServer.java:545) [Spigot.jar:git-Spigot-2440e18-60d7982]
        at net.minecraft.server.v1_13_R2.MinecraftServer.a(MinecraftServer.java:423) [Spigot.jar:git-Spigot-2440e18-60d7982]
        at net.minecraft.server.v1_13_R2.DedicatedServer.init(DedicatedServer.java:288) [Spigot.jar:git-Spigot-2440e18-60d7982]
        at net.minecraft.server.v1_13_R2.MinecraftServer.run(MinecraftServer.java:698) [Spigot.jar:git-Spigot-2440e18-60d7982]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_181]
```